### PR TITLE
Sidekiq 7 upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,14 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis
 
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", ruby-head]
+        ruby: ["3.0", "3.1", ruby-head]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,15 @@ jobs:
     services:
       redis:
         image: redis
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps port 6379 on service container to the host
+          - 6379:6379
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:
+    env:
+      REDIS_HOST: 'redis'
 
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", ruby-head]
+        ruby: ["3.0", "3.1", "3.2", ruby-head]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   test:

--- a/lib/sidekiq/batch.rb
+++ b/lib/sidekiq/batch.rb
@@ -292,7 +292,7 @@ module Sidekiq
         else
           # Otherwise finalize in sub batch complete callback
           cb_batch = self.new
-          cb_batch.callback_batch = true
+          cb_batch.callback_batch = 'true'
           Sidekiq.logger.debug {"Adding callback batch: #{cb_batch.bid} for batch: #{bid}"}
           cb_batch.on(:complete, "Sidekiq::Batch::Callback::Finalize#dispatch", opts)
           cb_batch.jobs do

--- a/lib/sidekiq/batch.rb
+++ b/lib/sidekiq/batch.rb
@@ -169,7 +169,7 @@ module Sidekiq
     end
 
     def valid?(batch = self)
-      valid = !Sidekiq.redis { |r| r.exists("invalidated-bid-#{batch.bid}") }
+      valid = Sidekiq.redis { |r| r.exists("invalidated-bid-#{batch.bid}") }.zero?
       batch.parent ? valid && valid?(batch.parent) : valid
     end
 

--- a/lib/sidekiq/batch.rb
+++ b/lib/sidekiq/batch.rb
@@ -248,7 +248,7 @@ module Sidekiq
         already_processed, _, callbacks, queue, parent_bid, callback_batch = Sidekiq.redis do |r|
           r.multi do |pipeline|
             pipeline.hget(batch_key, event_name)
-            pipeline.hset(batch_key, event_name, true)
+            pipeline.hset(batch_key, event_name, 'true')
             pipeline.smembers(callback_key)
             pipeline.hget(batch_key, "callback_queue")
             pipeline.hget(batch_key, "parent_bid")

--- a/sidekiq-batch.gemspec
+++ b/sidekiq-batch.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "fakeredis", "~> 0.8.0"
 end

--- a/spec/sidekiq/batch/middleware_spec.rb
+++ b/spec/sidekiq/batch/middleware_spec.rb
@@ -79,7 +79,7 @@ describe Sidekiq::Batch::Middleware do
 end
 
 describe Sidekiq::Batch::Middleware do
-  let(:config) { class_double(Sidekiq) }
+  let(:config) { instance_double(Sidekiq::Config) }
   let(:client_middleware) { double(Sidekiq::Middleware::Chain) }
 
   context 'client' do

--- a/spec/sidekiq/batch_spec.rb
+++ b/spec/sidekiq/batch_spec.rb
@@ -170,7 +170,7 @@ describe Sidekiq::Batch do
         Sidekiq::Batch.process_failed_job(bid, 'failed-job-id')
         Sidekiq::Batch.process_failed_job(bid, failed_jid)
         failed = Sidekiq.redis { |r| r.smembers("BID-#{bid}-failed") }
-        expect(failed).to eq(['xxx', 'failed-job-id'])
+        expect(failed).to eq(['failed-job-id', 'xxx'])
       end
     end
   end
@@ -245,7 +245,7 @@ describe Sidekiq::Batch do
       it 'returns and does not enqueue callbacks' do
         batch = Sidekiq::Batch.new
         batch.on(event, SampleCallback)
-        Sidekiq.redis { |r| r.hset("BID-#{batch.bid}", event, true) }
+        Sidekiq.redis { |r| r.hset("BID-#{batch.bid}", event, 'true') }
 
         expect(Sidekiq::Client).not_to receive(:push)
         Sidekiq::Batch.enqueue_callbacks(event, batch.bid)
@@ -290,8 +290,8 @@ describe Sidekiq::Batch do
           expect(Sidekiq::Client).to receive(:push_bulk).with(
             'class' => Sidekiq::Batch::Callback::Worker,
             'args' => [
-              ['SampleCallback2', event.to_s, opts2, batch.bid, nil],
-              ['SampleCallback', event.to_s, opts, batch.bid, nil]
+              ['SampleCallback', event.to_s, opts, batch.bid, nil],
+              ['SampleCallback2', event.to_s, opts2, batch.bid, nil]
             ],
             'queue' => 'default'
           )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,11 +2,9 @@ require "simplecov"
 SimpleCov.start
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'fakeredis/rspec'
 require 'sidekiq/batch'
 
 redis_opts = { url: "redis://127.0.0.1:6379/1" }
-redis_opts[:driver] = Redis::Connection::Memory if defined?(Redis::Connection::Memory)
 
 Sidekiq.configure_client do |config|
   config.redis = redis_opts
@@ -19,6 +17,12 @@ end
 RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
+
+  config.before do
+    Sidekiq.redis do |redis|
+      redis.flushdb
+    end
+  end
 end
 
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ SimpleCov.start
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'sidekiq/batch'
 
-redis_opts = { url: "redis://#{ENV.fetch('REDIS_HOST') { '127.0.0.1' }}:6379/1" }
+redis_opts = { url: "redis://127.0.0.1:6379/1" }
 
 Sidekiq.configure_client do |config|
   config.redis = redis_opts

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ SimpleCov.start
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'sidekiq/batch'
 
-redis_opts = { url: "redis://127.0.0.1:6379/1" }
+redis_opts = { url: "redis://#{ENV.fetch('REDIS_HOST') { '127.0.0.1' }}:6379/1" }
 
 Sidekiq.configure_client do |config|
   config.redis = redis_opts


### PR DESCRIPTION
- Use string version of true in redis. The redis-client gem does not support
  booleans [1]. Note that although previously, these values were passed as
  boolean from Ruby they were already returned as strings when read from redis.

- Replace fakeredis gem with an actual Redis in github actions because
  fakeredis is not compatible with Sidekiq 7 and the redis-client gem [2].

- Remove unsupported Ruby version from Github actions CI.


[1]: https://github.com/redis-rb/redis-client?tab=readme-ov-file#type-support
[2]: https://github.com/guilleiguaran/fakeredis/issues/270
